### PR TITLE
refactor: 유틸 패키지 `cn` 적용

### DIFF
--- a/apps/land/package.json
+++ b/apps/land/package.json
@@ -14,7 +14,8 @@
     "next": "^15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "swiper": "^11.2.2"
+    "swiper": "^11.2.2",
+    "@soup/utils": "workspace:^"
   },
   "devDependencies": {
     "@soup/config": "workspace:*",

--- a/apps/land/src/shared/utils/string.tsx
+++ b/apps/land/src/shared/utils/string.tsx
@@ -1,9 +1,3 @@
-import { ClassValue, clsx } from 'clsx';
-
-export function cn(...inputs: ClassValue[]): string {
-  return clsx(inputs);
-}
-
 export function parse(input: string, classNames?: string[]) {
   return input.split('\n').map((val, index) => (
     <p key={index} className={classNames && classNames[index]}>

--- a/apps/land/src/widgets/home/ui/OpinionUnit.tsx
+++ b/apps/land/src/widgets/home/ui/OpinionUnit.tsx
@@ -55,7 +55,7 @@ function OpinionBox({ children, reversed = false }: OpinionBoxProps) {
     <div
       className={cn(
         reversed ? 'talkboxLeft' : 'talkboxRight',
-        'border-border boxShadow px-18 flex items-center justify-center border-[1px] p-4',
+        'border-border boxShadow px-18 flex items-center justify-center border-[1px]',
       )}
     >
       {children}

--- a/apps/land/src/widgets/home/ui/OpinionUnit.tsx
+++ b/apps/land/src/widgets/home/ui/OpinionUnit.tsx
@@ -1,4 +1,5 @@
-import { cn, parse } from '@/shared/utils';
+import { cn } from '@soup/utils';
+import { parse } from '@/shared/utils';
 
 interface OpinionUnitProps {
   reversed: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/land:
     dependencies:
+      '@soup/utils':
+        specifier: workspace:^
+        version: link:../../packages/utils
       next:
         specifier: ^15.1.6
         version: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #7 

## 📝 작업 내용

- 기존 `land` 레포의 `shared` 에서 정의하여 사용하던 `cn` 함수의 참조를 변경했어요
- 유틸 패키지를 설치하고, 기존 사용하던 `cn` 함수를 삭제했어요.
