### PR TITLE
[FEAT] : 회원가입 API 연동

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@soup/utils": "workspace:*",
     "@tanstack/react-query": "^5.66.9",
     "@types/react-router-dom": "^5.3.3",
+    "axios": "^1.8.4",
     "dayjs": "^1.11.13",
     "jotai": "^2.12.1",
     "moment": "^2.30.1",

--- a/apps/web/src/features/signup/api/index.ts
+++ b/apps/web/src/features/signup/api/index.ts
@@ -1,0 +1,1 @@
+export * from './signup';

--- a/apps/web/src/features/signup/api/signup.ts
+++ b/apps/web/src/features/signup/api/signup.ts
@@ -1,0 +1,18 @@
+import { get, REQUEST } from '~/shared/api';
+
+interface IdValidationResponse {
+  result: boolean;
+  resultDesc: string;
+}
+
+interface IdValidationParams {
+  userId: string;
+}
+
+export const fetchIdValidation = async (id: string) => {
+  const response = await get<IdValidationResponse, IdValidationParams>({
+    request: REQUEST.CHECK_VALID_ID,
+    params: { userId: id },
+  });
+  return response.data.result;
+};

--- a/apps/web/src/features/signup/api/signup.ts
+++ b/apps/web/src/features/signup/api/signup.ts
@@ -1,4 +1,4 @@
-import { get, REQUEST } from '~/shared/api';
+import { get, post, REQUEST } from '~/shared/api';
 
 interface IdValidationResponse {
   result: boolean;
@@ -9,10 +9,38 @@ interface IdValidationParams {
   userId: string;
 }
 
+interface EmailCodeRequest {
+  email: string;
+}
+
+interface EmailCodeValidationRequest {
+  authId: number;
+  authCode: string;
+}
+
 export const fetchIdValidation = async (id: string) => {
   const response = await get<IdValidationResponse, IdValidationParams>({
     request: REQUEST.CHECK_VALID_ID,
     params: { userId: id },
   });
   return response.data.result;
+};
+
+export const fetchEmailCode = async (email: string) => {
+  const response = await post<EmailCodeRequest>({
+    request: REQUEST.SEND_EMAIL_CODE,
+    data: { email: email },
+  });
+  return response.data;
+};
+
+export const fetchEmailCodeValidation = async (
+  authId: number,
+  authCode: string,
+) => {
+  const response = await post<EmailCodeValidationRequest>({
+    request: REQUEST.CHECK_VALID_EMAIL_CODE,
+    data: { authId: authId, authCode: authCode },
+  });
+  return response.status === 200;
 };

--- a/apps/web/src/features/signup/api/signup.ts
+++ b/apps/web/src/features/signup/api/signup.ts
@@ -1,4 +1,5 @@
 import { get, post, REQUEST } from '~/shared/api';
+import { SignupInfo } from '../types';
 
 interface IdValidationResponse {
   result: boolean;
@@ -43,4 +44,12 @@ export const fetchEmailCodeValidation = async (
     data: { authId: authId, authCode: authCode },
   });
   return response.status === 200;
+};
+
+export const fetchUserJoin = async (data: SignupInfo) => {
+  const response = await post<SignupInfo>({
+    request: REQUEST.SIGNUP,
+    data: data,
+  });
+  return response.status;
 };

--- a/apps/web/src/features/signup/model/contexts/index.ts
+++ b/apps/web/src/features/signup/model/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './signup';

--- a/apps/web/src/features/signup/model/contexts/signup.ts
+++ b/apps/web/src/features/signup/model/contexts/signup.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+import type { FormState } from '~/features/signup/types';
+
+export const SignupContext = createContext<{
+  clicked: FormState;
+  setClicked: React.Dispatch<React.SetStateAction<FormState>>;
+  valid: FormState;
+  setValid: React.Dispatch<React.SetStateAction<FormState>>;
+} | null>(null);

--- a/apps/web/src/features/signup/model/hooks/index.ts
+++ b/apps/web/src/features/signup/model/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useSignupContext } from './useSignupContext';

--- a/apps/web/src/features/signup/model/hooks/useSignupContext.ts
+++ b/apps/web/src/features/signup/model/hooks/useSignupContext.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+import { SignupContext } from '~/features/signup/model';
+
+export default function useSignupContext() {
+  const context = useContext(SignupContext);
+  if (!context) {
+    throw new Error(
+      'useSignupContext는 SignupProvider 안에서만 사용할 수 있어요.',
+    );
+  }
+  return context;
+}

--- a/apps/web/src/features/signup/model/index.ts
+++ b/apps/web/src/features/signup/model/index.ts
@@ -1,2 +1,5 @@
 export * from './constants';
+export * from './contexts';
+export * from './hooks';
+export * from './providers';
 export * from './utils';

--- a/apps/web/src/features/signup/model/providers/index.ts
+++ b/apps/web/src/features/signup/model/providers/index.ts
@@ -1,0 +1,1 @@
+export { default as SignupProvider } from './signup';

--- a/apps/web/src/features/signup/model/providers/signup.tsx
+++ b/apps/web/src/features/signup/model/providers/signup.tsx
@@ -1,0 +1,15 @@
+import { type ReactNode, useState } from 'react';
+
+import { FormState } from '~/features/signup/types';
+import { clickedState, SignupContext } from '~/features/signup/model';
+
+export default function SignupProvider({ children }: { children: ReactNode }) {
+  const [clicked, setClicked] = useState<FormState>(clickedState);
+  const [valid, setValid] = useState<FormState>(clickedState);
+
+  return (
+    <SignupContext.Provider value={{ clicked, setClicked, valid, setValid }}>
+      {children}
+    </SignupContext.Provider>
+  );
+}

--- a/apps/web/src/features/signup/model/providers/signup.tsx
+++ b/apps/web/src/features/signup/model/providers/signup.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import React, { type ReactNode, useState } from 'react';
 
 import { FormState } from '~/features/signup/types';
 import { clickedState, SignupContext } from '~/features/signup/model';

--- a/apps/web/src/features/signup/model/utils/handleFormSubmit.ts
+++ b/apps/web/src/features/signup/model/utils/handleFormSubmit.ts
@@ -1,5 +1,8 @@
 import { type SignupInfo } from '~/features/signup/types';
+import { fetchUserJoin } from '~/features/signup/api';
 
-export const handleFormSubmit = (data: SignupInfo) => {
-  console.log(data);
+export const handleFormSubmit = async (data: SignupInfo) => {
+  const response = await fetchUserJoin(data);
+  if (response === 200) alert('success');
+  else alert('fail');
 };

--- a/apps/web/src/features/signup/types/form.ts
+++ b/apps/web/src/features/signup/types/form.ts
@@ -1,6 +1,11 @@
-import type { FieldErrors, UseFormRegister } from 'react-hook-form';
+import type {
+  FieldErrors,
+  UseFormRegister,
+  UseFormWatch,
+} from 'react-hook-form';
 import { type SignupInfo } from '~/features/signup/types';
 import { USER } from '~/features/signup/model';
+import { ChangeEvent } from 'react';
 
 export type FormItem = keyof typeof USER;
 
@@ -17,10 +22,12 @@ export interface FormInputProps {
   disabled?: boolean;
   className?: string;
   errors?: boolean;
+  onChangeHandler?: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
 export interface FormUnitProps {
   id: FormItem;
   errors: FieldErrors<SignupInfo>;
   register: UseFormRegister<SignupInfo>;
+  watch: UseFormWatch<SignupInfo>;
 }

--- a/apps/web/src/features/signup/ui/EmailVerification.tsx
+++ b/apps/web/src/features/signup/ui/EmailVerification.tsx
@@ -1,18 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button, Input } from '@soup/design-system';
 
-export default function EmailVerification({
-  handler,
-}: {
-  handler: () => void;
-}) {
+interface EmailVerificationProps {
+  handler: (target: string) => void;
+}
+
+export default function EmailVerification({ handler }: EmailVerificationProps) {
+  const [value, setValue] = useState<string>('');
+
   return (
     <div className="relative mt-1 flex w-full items-end">
       <Input
         id="emailVerification"
         placeholder="인증코드를 입력해주세요"
         className="flex-1"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
       />
 
       <Button
@@ -20,7 +24,10 @@ export default function EmailVerification({
         size="sm"
         className="ml-3 h-[39px]"
         type="button"
-        onClick={handler}
+        onClick={() => {
+          handler(value);
+          console.log(value);
+        }}
       >
         인증 확인
       </Button>

--- a/apps/web/src/features/signup/ui/FormInput.tsx
+++ b/apps/web/src/features/signup/ui/FormInput.tsx
@@ -11,6 +11,7 @@ export default function FormInput({
   register,
   disabled = false,
   className = '',
+  onChangeHandler,
 }: FormInputProps) {
   const formConfig = FORM[id];
   return (
@@ -25,7 +26,7 @@ export default function FormInput({
       )}
       type={USER[id]}
       disabled={!!disabled}
-      {...register(USER[id], { required: true })}
+      {...register(USER[id], { required: true, onChange: onChangeHandler })}
     />
   );
 }

--- a/apps/web/src/features/signup/ui/FormUnit.tsx
+++ b/apps/web/src/features/signup/ui/FormUnit.tsx
@@ -10,7 +10,11 @@ const Description = ({ content }: { content: string }) => (
   <p className="text-light mt-1 p-0 text-sm font-light">{content}</p>
 );
 
-export default function FormUnit({ id, errors, register }: FormUnitProps) {
+export default function FormUnit({
+  id,
+  errors,
+  register,
+}: Omit<FormUnitProps, 'watch'>) {
   return (
     <div className="relative flex w-full flex-col items-start">
       <p

--- a/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
+++ b/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
@@ -61,10 +61,7 @@ export default function FormUnitWithButton({
         className="ml-3 h-[39px]"
         locked={!isFormValid(USER[id])}
         type="button"
-        onClick={() => {
-          console.log(watch(formId));
-          handler(watch(formId));
-        }}
+        onClick={() => handler(watch(formId))}
       >
         {FORM[id].button}
       </Button>

--- a/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
+++ b/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 
 import { Button } from '@soup/design-system';
 import { cn } from '@soup/utils';
@@ -13,8 +13,10 @@ import { FormInput } from '~/features/signup/ui';
 
 interface ButtonedUnitProps extends FormUnitProps {
   valid: FormState;
-  handler: () => void;
+  handler: (target: string) => void;
   isFormValid: (key: SignupItem) => boolean;
+  setClicked: Dispatch<SetStateAction<FormState>>;
+  setValid: Dispatch<SetStateAction<FormState>>;
 }
 
 export default function FormUnitWithButton({
@@ -24,8 +26,22 @@ export default function FormUnitWithButton({
   register,
   handler,
   isFormValid,
+  watch,
+  setClicked,
+  setValid,
 }: ButtonedUnitProps) {
   const formId = USER[id as 'ID' | 'EMAIL'];
+  const handleChange = () => {
+    setClicked((prev) => ({
+      ...prev,
+      [formId]: false,
+    }));
+    setValid((prev) => ({
+      ...prev,
+      [formId]: false,
+    }));
+  };
+
   return (
     <div className="relative flex w-full items-end">
       <p
@@ -38,14 +54,17 @@ export default function FormUnitWithButton({
           ? errors[USER[id]]?.message
           : valid[formId] && '*인증 완료'}
       </p>
-      <FormInput id={id} register={register} />
+      <FormInput id={id} register={register} onChangeHandler={handleChange} />
       <Button
         color="normal"
         size="sm"
         className="ml-3 h-[39px]"
         locked={!isFormValid(USER[id])}
         type="button"
-        onClick={handler}
+        onClick={() => {
+          console.log(watch(formId));
+          handler(watch(formId));
+        }}
       >
         {FORM[id].button}
       </Button>

--- a/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
+++ b/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
@@ -1,9 +1,9 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 
 import { Button } from '@soup/design-system';
 import { cn } from '@soup/utils';
 
-import { FORM, USER } from '~/features/signup/model';
+import { FORM, USER, useSignupContext } from '~/features/signup/model';
 import type {
   FormState,
   FormUnitProps,
@@ -15,8 +15,6 @@ interface ButtonedUnitProps extends FormUnitProps {
   valid: FormState;
   handler: (target: string) => void;
   isFormValid: (key: SignupItem) => boolean;
-  setClicked: Dispatch<SetStateAction<FormState>>;
-  setValid: Dispatch<SetStateAction<FormState>>;
 }
 
 export default function FormUnitWithButton({
@@ -27,10 +25,9 @@ export default function FormUnitWithButton({
   handler,
   isFormValid,
   watch,
-  setClicked,
-  setValid,
 }: ButtonedUnitProps) {
   const formId = USER[id as 'ID' | 'EMAIL'];
+  const { setClicked, setValid } = useSignupContext();
   const handleChange = () => {
     setClicked((prev) => ({
       ...prev,

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -109,6 +109,14 @@ export default function SignupForm() {
       );
   };
 
+  const formProps = {
+    errors: errors,
+    valid: valid,
+    register: register,
+    isFormValid: isFormValid,
+    watch: watch,
+  };
+
   return (
     <form
       className="mt-30 flex flex-col gap-y-7 p-16 pt-0"
@@ -117,22 +125,14 @@ export default function SignupForm() {
       <FormUnit id="NAME" errors={errors} register={register} />
       <FormUnitWithButton
         id="ID"
-        errors={errors}
-        valid={valid}
-        register={register}
         handler={handleUsernameValidation}
-        isFormValid={isFormValid}
-        watch={watch}
+        {...formProps}
       />
       <div>
         <FormUnitWithButton
           id="EMAIL"
-          errors={errors}
-          valid={valid}
-          register={register}
           handler={handleEmailValidation}
-          isFormValid={isFormValid}
-          watch={watch}
+          {...formProps}
         />
         {clicked[USER.EMAIL] && !valid[USER.EMAIL] && (
           <EmailVerification handler={handleEmailCodeValidation} />

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -1,22 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 
+import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 
 import {
   checkValidation,
-  clickedState,
   FORM,
   handleFormSubmit,
   USER,
-  validState,
+  useSignupContext,
 } from '~/features/signup/model';
-import type {
-  FormState,
-  SignupInfo,
-  SignupItem,
-} from '~/features/signup/types';
+import type { SignupInfo, SignupItem } from '~/features/signup/types';
 import {
   FormSubmit,
   FormUnit,
@@ -34,9 +29,8 @@ const Description = ({ content }: { content: string }) => (
 );
 
 export default function SignupForm() {
-  const [clicked, setClicked] = useState<FormState>(clickedState);
-  const [valid, setValid] = useState<FormState>(validState);
-  const authId = 0;
+  const { clicked, setClicked, valid, setValid } = useSignupContext();
+  const authId = 0; /**이메일 인증 백엔드 미구현으로 인해 샘플 응답값을 생성했습니다. */
   const schema = z.object({
     [USER.NAME]: z.string().min(1, '*'),
     [USER.ID]: z
@@ -129,8 +123,6 @@ export default function SignupForm() {
         handler={handleUsernameValidation}
         isFormValid={isFormValid}
         watch={watch}
-        setClicked={setClicked}
-        setValid={setValid}
       />
       <div>
         <FormUnitWithButton
@@ -141,8 +133,6 @@ export default function SignupForm() {
           handler={handleEmailValidation}
           isFormValid={isFormValid}
           watch={watch}
-          setClicked={setClicked}
-          setValid={setValid}
         />
         {clicked[USER.EMAIL] && !valid[USER.EMAIL] && (
           <EmailVerification handler={handleEmailCodeValidation} />

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -23,6 +23,7 @@ import {
   EmailVerification,
   FormUnitWithButton,
 } from '~/features/signup/ui';
+import { fetchIdValidation } from '~/features/signup/api';
 
 const Description = ({ content }: { content: string }) => (
   <p className="text-light mt-1 p-0 text-sm font-light">{content}</p>
@@ -43,10 +44,10 @@ export default function SignupForm() {
     [USER.EMAIL]: z
       .string()
       .min(1, '*')
-      .refine(() => clicked.email, {
+      .refine(() => clicked[USER.EMAIL], {
         message: '*이메일 인증 필요',
       })
-      .refine(() => valid.email, { message: '*코드가 틀렸습니다' }),
+      .refine(() => valid[USER.EMAIL], { message: '*코드가 틀렸습니다' }),
     [USER.PW]: z
       .string()
       .min(8, '*')
@@ -63,32 +64,36 @@ export default function SignupForm() {
     watch,
     formState: { errors },
     clearErrors,
+    setError,
   } = useForm<SignupInfo>({
     resolver: zodResolver(schema),
   });
 
   const isFormValid = (key: SignupItem) => checkValidation(watch(key), key);
 
-  const handleUsernameValidation = () => {
+  const handleUsernameValidation = async (target: string) => {
     setClicked((prev) => ({
       ...prev,
-      username: true,
+      [USER.ID]: true,
     }));
-    setValid((prev) => ({ ...prev, username: true }));
-    clearErrors(USER.ID);
+    fetchIdValidation(target).then((isValid) => {
+      setValid((prev) => ({ ...prev, [USER.ID]: isValid }));
+      if (isValid) clearErrors(USER.ID);
+      else setError(USER.ID, { message: '*이미 사용중인 아이디입니다' });
+    });
   };
 
-  const handleEmailValidation = () => {
+  const handleEmailValidation = async () => {
     setClicked((prev) => ({
       ...prev,
-      email: true,
+      [USER.EMAIL]: true,
     }));
   };
 
   const handleEmailCodeValidation = () => {
     setValid((prev) => ({
       ...prev,
-      email: true,
+      [USER.EMAIL]: true,
     }));
     clearErrors(USER.EMAIL);
   };
@@ -106,6 +111,9 @@ export default function SignupForm() {
         register={register}
         handler={handleUsernameValidation}
         isFormValid={isFormValid}
+        watch={watch}
+        setClicked={setClicked}
+        setValid={setValid}
       />
       <div>
         <FormUnitWithButton
@@ -115,8 +123,11 @@ export default function SignupForm() {
           register={register}
           handler={handleEmailValidation}
           isFormValid={isFormValid}
+          watch={watch}
+          setClicked={setClicked}
+          setValid={setValid}
         />
-        {clicked.email && !valid.email && (
+        {clicked[USER.EMAIL] && !valid[USER.EMAIL] && (
           <EmailVerification handler={handleEmailCodeValidation} />
         )}
         <Description content={FORM.EMAIL.description || ''} />

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -23,7 +23,11 @@ import {
   EmailVerification,
   FormUnitWithButton,
 } from '~/features/signup/ui';
-import { fetchIdValidation } from '~/features/signup/api';
+import {
+  fetchEmailCode,
+  fetchEmailCodeValidation,
+  fetchIdValidation,
+} from '~/features/signup/api';
 
 const Description = ({ content }: { content: string }) => (
   <p className="text-light mt-1 p-0 text-sm font-light">{content}</p>
@@ -32,6 +36,7 @@ const Description = ({ content }: { content: string }) => (
 export default function SignupForm() {
   const [clicked, setClicked] = useState<FormState>(clickedState);
   const [valid, setValid] = useState<FormState>(validState);
+  const authId = 0;
   const schema = z.object({
     [USER.NAME]: z.string().min(1, '*'),
     [USER.ID]: z
@@ -83,19 +88,31 @@ export default function SignupForm() {
     });
   };
 
-  const handleEmailValidation = async () => {
+  const handleEmailValidation = async (email: string) => {
     setClicked((prev) => ({
       ...prev,
       [USER.EMAIL]: true,
     }));
+    fetchEmailCode(email).then((response) => console.log(response));
   };
 
-  const handleEmailCodeValidation = () => {
-    setValid((prev) => ({
-      ...prev,
-      [USER.EMAIL]: true,
-    }));
-    clearErrors(USER.EMAIL);
+  const handleEmailCodeValidation = (authCode: string) => {
+    fetchEmailCodeValidation(authId, authCode)
+      .then((isValid) => {
+        setValid((prev) => ({ ...prev, [USER.EMAIL]: isValid }));
+        if (isValid) {
+          clearErrors(USER.EMAIL);
+          setValid((prev) => ({
+            ...prev,
+            [USER.EMAIL]: true,
+          }));
+        } else setError(USER.EMAIL, { message: '*코드가 틀렸습니다' });
+      })
+      .catch(() =>
+        setError(USER.EMAIL, {
+          message: '*인증에 실패했어요. 다시 시도해 주세요.',
+        }),
+      );
   };
 
   return (

--- a/apps/web/src/pages/signup/ui/SignupPage.tsx
+++ b/apps/web/src/pages/signup/ui/SignupPage.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { SignupProvider } from '~/features/signup/model';
 import { SignupForm } from '~/features/signup/ui';
 import { AuthHeader } from '~/shared/ui';
 
 export default function SignupPage() {
   return (
-    <div className="relative flex size-full flex-col">
-      <AuthHeader title="회원가입" />
-      <SignupForm />
-    </div>
+    <SignupProvider>
+      <div className="relative flex size-full flex-col">
+        <AuthHeader title="회원가입" />
+        <SignupForm />
+      </div>
+    </SignupProvider>
   );
 }

--- a/apps/web/src/shared/api/axios.ts
+++ b/apps/web/src/shared/api/axios.ts
@@ -1,0 +1,28 @@
+import axios, { AxiosHeaders, AxiosResponse } from 'axios';
+
+interface GetRequestParams<TParams> {
+  request: string;
+  headers: AxiosHeaders;
+  params: TParams;
+}
+
+const instance = axios.create({
+  baseURL: 'http://student-p.p-e.kr/api',
+});
+
+export async function get<TResponse, TParams = unknown>(
+  config: GetRequestParams<TParams>,
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, params } = config;
+  try {
+    const response = await instance.get<TResponse>(request, {
+      params: params,
+      headers: headers,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}

--- a/apps/web/src/shared/api/axios.ts
+++ b/apps/web/src/shared/api/axios.ts
@@ -2,7 +2,7 @@ import axios, { AxiosHeaders, AxiosResponse } from 'axios';
 
 interface GetRequestParams<TParams> {
   request: string;
-  headers: AxiosHeaders;
+  headers?: AxiosHeaders;
   params: TParams;
 }
 
@@ -17,7 +17,7 @@ export async function get<TResponse, TParams = unknown>(
   try {
     const response = await instance.get<TResponse>(request, {
       params: params,
-      headers: headers,
+      headers: headers || undefined,
     });
     return response;
   } catch (error: unknown) {

--- a/apps/web/src/shared/api/axios.ts
+++ b/apps/web/src/shared/api/axios.ts
@@ -6,6 +6,12 @@ interface GetRequestParams<TParams> {
   params: TParams;
 }
 
+interface PostRequestParams<TData> {
+  request: string;
+  headers?: AxiosHeaders;
+  data: TData;
+}
+
 const instance = axios.create({
   baseURL: 'http://student-p.p-e.kr/api',
 });
@@ -17,6 +23,26 @@ export async function get<TResponse, TParams = unknown>(
   try {
     const response = await instance.get<TResponse>(request, {
       params: params,
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function post<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>,
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, data } = config;
+  try {
+    const response = await instance.post<
+      TResponse,
+      AxiosResponse<TResponse>,
+      TData
+    >(request, data, {
       headers: headers || undefined,
     });
     return response;

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -1,0 +1,2 @@
+export * from './axios';
+export * from './request';

--- a/apps/web/src/shared/api/request.ts
+++ b/apps/web/src/shared/api/request.ts
@@ -1,4 +1,5 @@
 export const REQUEST = {
+  SIGNUP: '/v1/user/join',
   CHECK_VALID_ID: '/v1/user/valid/id',
   CHECK_VALID_EMAIL_CODE: '/v1/email/auth',
   SEND_EMAIL_CODE: '/v1/email/auth/send',

--- a/apps/web/src/shared/api/request.ts
+++ b/apps/web/src/shared/api/request.ts
@@ -1,0 +1,3 @@
+export const REQUEST = {
+  CHECK_VALID_ID: '/v1/user/valid/id',
+};

--- a/apps/web/src/shared/api/request.ts
+++ b/apps/web/src/shared/api/request.ts
@@ -1,3 +1,5 @@
 export const REQUEST = {
   CHECK_VALID_ID: '/v1/user/valid/id',
+  CHECK_VALID_EMAIL_CODE: '/v1/email/auth',
+  SEND_EMAIL_CODE: '/v1/email/auth/send',
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
+      axios:
+        specifier: ^1.8.4
+        version: 1.8.4
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -1912,6 +1915,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1922,6 +1928,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.8.4:
+    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
 
   babel-plugin-apply-mdx-type-prop@1.6.22:
     resolution: {integrity: sha512-VefL+8o+F/DfK24lPZMtJctrCVOfgbqLAGZSkxwhazQv4VxPg3Za/i40fu22KR2m8eEda+IfSOlPLUSIiLcnCQ==}
@@ -2089,6 +2098,10 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
 
@@ -2218,6 +2231,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2540,6 +2557,15 @@ packages:
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2547,6 +2573,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -3228,6 +3258,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -3564,6 +3602,9 @@ packages:
 
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6125,6 +6166,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.20(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
@@ -6138,6 +6181,14 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.8.4:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   babel-plugin-apply-mdx-type-prop@1.6.22(@babel/core@7.12.9):
     dependencies:
@@ -6312,6 +6363,10 @@ snapshots:
       color-string: 1.9.1
     optional: true
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@1.0.8: {}
 
   commander@2.20.3:
@@ -6428,6 +6483,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -6889,6 +6946,8 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  follow-redirects@1.15.9: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -6897,6 +6956,13 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -7589,6 +7655,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -7876,6 +7948,8 @@ snapshots:
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #43 

## 📝 작업 내용

> 회원가입 로직 API를 연동했어요.
- 이제 복잡한 회원가입 폼 상태를 커스텀 `context`로 관리해요.
