### PR TITLE
[FEAT] : 로그인 API, 회원가입 API(이메일 인증) 연동

### DIFF
--- a/apps/web/src/features/login/api/index.ts
+++ b/apps/web/src/features/login/api/index.ts
@@ -1,0 +1,1 @@
+export * from './login';

--- a/apps/web/src/features/login/api/login.ts
+++ b/apps/web/src/features/login/api/login.ts
@@ -1,0 +1,18 @@
+import { post, REQUEST } from '~/shared/api';
+import { UserInfo } from '~/features/login/types';
+
+interface UserLoginResponse {
+  token: {
+    grantType: string;
+    accessToken: string;
+    refreshToken: string;
+  };
+}
+
+export const fetchUserLogin = async (data: UserInfo) => {
+  const response = await post<UserInfo, UserLoginResponse>({
+    request: REQUEST.LOGIN,
+    data: data,
+  });
+  return response.data.token;
+};

--- a/apps/web/src/features/login/model/hooks/index.ts
+++ b/apps/web/src/features/login/model/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useSubmit';

--- a/apps/web/src/features/login/model/hooks/useSubmit.ts
+++ b/apps/web/src/features/login/model/hooks/useSubmit.ts
@@ -1,7 +1,8 @@
 import type { UserInfo } from '~/features/login/types';
+import { fetchUserLogin } from '~/features/login/api';
 
-export const useSubmit = ({ username, password }: UserInfo) => {
-  alert(
-    `id: ${username}\npw: ${password}\n\n로그인 요청되었습니다\n세부 구현 로직 차후 구현`,
-  );
+export const useSubmit = async (data: UserInfo) => {
+  const response = await fetchUserLogin(data);
+  const { accessToken, refreshToken } = response;
+  alert(`success. accessToken: ${accessToken}, refreshToken: ${refreshToken}`);
 };

--- a/apps/web/src/features/login/model/hooks/useSubmit.ts
+++ b/apps/web/src/features/login/model/hooks/useSubmit.ts
@@ -1,8 +1,0 @@
-import type { UserInfo } from '~/features/login/types';
-import { fetchUserLogin } from '~/features/login/api';
-
-export const useSubmit = async (data: UserInfo) => {
-  const response = await fetchUserLogin(data);
-  const { accessToken, refreshToken } = response;
-  alert(`success. accessToken: ${accessToken}, refreshToken: ${refreshToken}`);
-};

--- a/apps/web/src/features/login/model/index.ts
+++ b/apps/web/src/features/login/model/index.ts
@@ -1,1 +1,0 @@
-export * from './hooks';

--- a/apps/web/src/features/login/types/user.ts
+++ b/apps/web/src/features/login/types/user.ts
@@ -1,4 +1,4 @@
 export type UserInfo = {
-  username: string;
+  userId: string;
   password: string;
 };

--- a/apps/web/src/features/login/ui/LoginForm.tsx
+++ b/apps/web/src/features/login/ui/LoginForm.tsx
@@ -13,17 +13,19 @@ export default function LoginForm() {
   return (
     <form onSubmit={handleSubmit(useSubmit)}>
       <Input
+        id="LoginUserId"
         label="아이디"
         placeholder="아이디를 입력해주세요"
         className="mb-7"
-        {...register('username', { required: '아이디를 입력하세요' })}
+        {...register('userId', { required: '아이디를 입력하세요' })}
       />
       <Input
-        type="password"
+        id="LoginPassword"
         label="비밀번호"
         placeholder="비밀번호를 입력해주세요"
         className="mb-3"
         {...register('password', { required: '비밀번호를 입력하세요' })}
+        showPasswordButton
       />
       <LoginOption className="mb-11" />
       <Button

--- a/apps/web/src/features/login/ui/LoginForm.tsx
+++ b/apps/web/src/features/login/ui/LoginForm.tsx
@@ -1,17 +1,30 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
+import { useSetAtom } from 'jotai';
 
 import { Button, Input } from '@soup/design-system';
 
 import { LoginOption } from '~/features/login/ui';
 import { type UserInfo } from '~/features/login/types';
-import { useSubmit } from '~/features/login/model';
+import { fetchUserLogin } from '~/features/login/api';
+import { userAtom } from '~/shared/atoms';
+import { PATH } from '~/shared/constants';
 
 export default function LoginForm() {
   const { register, handleSubmit } = useForm<UserInfo>();
+  const navigate = useNavigate();
+  const setUserAtom = useSetAtom(userAtom);
+
+  const handleFormSubmit = async (data: UserInfo) => {
+    fetchUserLogin(data).then((response) => {
+      setUserAtom(response);
+      navigate(PATH.HOME);
+    });
+  };
 
   return (
-    <form onSubmit={handleSubmit(useSubmit)}>
+    <form onSubmit={handleSubmit(handleFormSubmit)}>
       <Input
         id="LoginUserId"
         label="아이디"

--- a/apps/web/src/features/signup/api/signup.ts
+++ b/apps/web/src/features/signup/api/signup.ts
@@ -1,5 +1,5 @@
 import { get, post, REQUEST } from '~/shared/api';
-import { SignupInfo } from '../types';
+import { AuthId, SignupInfo } from '../types';
 
 interface IdValidationResponse {
   result: boolean;
@@ -12,6 +12,10 @@ interface IdValidationParams {
 
 interface EmailCodeRequest {
   email: string;
+}
+
+interface EmailCodeResponse {
+  authId: number;
 }
 
 interface EmailCodeValidationRequest {
@@ -28,7 +32,7 @@ export const fetchIdValidation = async (id: string) => {
 };
 
 export const fetchEmailCode = async (email: string) => {
-  const response = await post<EmailCodeRequest>({
+  const response = await post<EmailCodeRequest, EmailCodeResponse>({
     request: REQUEST.SEND_EMAIL_CODE,
     data: { email: email },
   });
@@ -46,7 +50,7 @@ export const fetchEmailCodeValidation = async (
   return response.status === 200;
 };
 
-export const fetchUserJoin = async (data: SignupInfo) => {
+export const fetchUserJoin = async (data: SignupInfo & AuthId) => {
   const response = await post<SignupInfo>({
     request: REQUEST.SIGNUP,
     data: data,

--- a/apps/web/src/features/signup/model/constants/form.ts
+++ b/apps/web/src/features/signup/model/constants/form.ts
@@ -1,4 +1,4 @@
-import { FormField, FormItem } from '~/features/signup/types';
+import { FormError, FormField, FormItem } from '~/features/signup/types';
 
 export const FORM: Record<FormItem, FormField> = {
   NAME: {
@@ -24,5 +24,23 @@ export const FORM: Record<FormItem, FormField> = {
     placeholder: '비밀번호를 입력해주세요',
     description: '영어 + 특수문자 + 숫자 조합으로 최소 8자',
     button: null,
+  },
+};
+
+export const ERROR: Record<'ID' | 'EMAIL' | 'PW', FormError> = {
+  ID: {
+    ACTION_NOT_COMPLETED: '*중복 확인 필요',
+    AUTH_FAILURE: '*이미 사용중인 아이디입니다.',
+    AUTH_EXCEPTION: '*인증에 실패했어요. 다시 시도해 주세요.',
+  },
+  EMAIL: {
+    ACTION_NOT_COMPLETED: '*중복 확인 필요',
+    AUTH_FAILURE: '*코드가 틀렸습니다.',
+    AUTH_EXCEPTION: '*인증에 실패했어요. 다시 시도해 주세요.',
+  },
+  PW: {
+    ACTION_NOT_COMPLETED: '*중복 확인 필요',
+    AUTH_FAILURE: '*비밀번호는 8자 이상이어야 해요.',
+    AUTH_EXCEPTION: '*영어, 특수문자, 숫자를 모두 포함해야 해요.',
   },
 };

--- a/apps/web/src/features/signup/model/constants/user.ts
+++ b/apps/web/src/features/signup/model/constants/user.ts
@@ -1,5 +1,5 @@
 export const USER = {
-  NAME: 'name',
+  NAME: 'username',
   ID: 'userId',
   EMAIL: 'email',
   PW: 'password',

--- a/apps/web/src/features/signup/model/hooks/index.ts
+++ b/apps/web/src/features/signup/model/hooks/index.ts
@@ -1,1 +1,3 @@
 export { default as useSignupContext } from './useSignupContext';
+export { default as useSignupHandlers } from './useSignupHandlers';
+export { default as useSignupSchema } from './useSignupSchema';

--- a/apps/web/src/features/signup/model/hooks/useSignupHandlers.ts
+++ b/apps/web/src/features/signup/model/hooks/useSignupHandlers.ts
@@ -1,0 +1,89 @@
+// useSignupHandlers.ts
+import React, { useState } from 'react';
+
+import { UseFormClearErrors, UseFormSetError } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import { ERROR, USER } from '~/features/signup/model';
+import { FormState, SignupInfo } from '~/features/signup/types';
+import { PATH } from '~/shared/constants';
+import {
+  fetchEmailCode,
+  fetchEmailCodeValidation,
+  fetchIdValidation,
+  fetchUserJoin,
+} from '~/features/signup/api';
+import { AxiosError } from 'axios';
+
+interface SignupHandlerProps {
+  setClicked: React.Dispatch<React.SetStateAction<FormState>>;
+  setValid: React.Dispatch<React.SetStateAction<FormState>>;
+  clearErrors: UseFormClearErrors<SignupInfo>;
+  setError: UseFormSetError<SignupInfo>;
+}
+
+export default function useSignupHandlers({
+  setClicked,
+  setValid,
+  clearErrors,
+  setError,
+}: SignupHandlerProps) {
+  const navigate = useNavigate();
+  const [authId, setAuthId] = useState<number | undefined>(undefined);
+
+  const handleUsernameValidation = async (target: string) => {
+    setClicked((prev) => ({
+      ...prev,
+      [USER.ID]: true,
+    }));
+    try {
+      const isValid = await fetchIdValidation(target);
+      setValid((prev) => ({ ...prev, [USER.ID]: isValid }));
+      if (isValid) clearErrors(USER.ID);
+      else setError(USER.ID, { message: ERROR.ID.AUTH_FAILURE });
+    } catch {
+      setError(USER.ID, {
+        message: ERROR.ID.AUTH_EXCEPTION,
+      });
+    }
+  };
+
+  const handleEmailValidation = async (email: string) => {
+    setClicked((prev) => ({
+      ...prev,
+      [USER.EMAIL]: true,
+    }));
+    const { authId } = await fetchEmailCode(email);
+    setAuthId(authId);
+  };
+
+  const handleEmailCodeValidation = async (authCode: string) => {
+    try {
+      const isValid = await fetchEmailCodeValidation(authId!, authCode);
+      setValid((prev) => ({ ...prev, [USER.EMAIL]: isValid }));
+      if (isValid) clearErrors(USER.EMAIL);
+      else setError(USER.EMAIL, { message: ERROR.EMAIL.AUTH_FAILURE });
+    } catch {
+      setError(USER.EMAIL, {
+        message: ERROR.EMAIL.AUTH_EXCEPTION,
+      });
+    }
+  };
+
+  const handleFormSubmit = async (data: SignupInfo) => {
+    try {
+      const resCode = await fetchUserJoin({ ...data, authId: authId! });
+      if (resCode === 200) navigate(PATH.LOGIN);
+    } catch (error) {
+      const { message } = error as AxiosError;
+      alert(message);
+    }
+  };
+
+  return {
+    handleUsernameValidation,
+    handleEmailValidation,
+    handleEmailCodeValidation,
+    handleFormSubmit,
+  };
+}

--- a/apps/web/src/features/signup/model/hooks/useSignupSchema.ts
+++ b/apps/web/src/features/signup/model/hooks/useSignupSchema.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { ERROR, USER } from '~/features/signup/model';
+import { FormState } from '~/features/signup/types';
+
+interface SignupSchemaProps {
+  clicked: FormState;
+  valid: FormState;
+}
+
+export default function useSignupSchema({ clicked, valid }: SignupSchemaProps) {
+  const schema = z.object({
+    [USER.NAME]: z.string().min(1, '*'),
+    [USER.ID]: z
+      .string()
+      .min(1, '*')
+      .refine(() => clicked[USER.ID], {
+        message: ERROR.ID.ACTION_NOT_COMPLETED,
+      })
+      .refine(() => valid[USER.ID], { message: ERROR.ID.AUTH_FAILURE }),
+    [USER.EMAIL]: z
+      .string()
+      .min(1, '*')
+      .refine(() => clicked[USER.EMAIL], {
+        message: ERROR.EMAIL.ACTION_NOT_COMPLETED,
+      })
+      .refine(() => valid[USER.EMAIL], { message: ERROR.EMAIL.AUTH_FAILURE }),
+    [USER.PW]: z
+      .string()
+      .min(1, '*')
+      .min(8, ERROR.PW.AUTH_FAILURE)
+      .refine(
+        (password) => /^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,}$/.test(password),
+        {
+          message: ERROR.PW.AUTH_EXCEPTION,
+        },
+      ),
+  });
+  return schema;
+}

--- a/apps/web/src/features/signup/model/utils/handleFormSubmit.ts
+++ b/apps/web/src/features/signup/model/utils/handleFormSubmit.ts
@@ -1,8 +1,0 @@
-import { type SignupInfo } from '~/features/signup/types';
-import { fetchUserJoin } from '~/features/signup/api';
-
-export const handleFormSubmit = async (data: SignupInfo) => {
-  const response = await fetchUserJoin(data);
-  if (response === 200) alert('success');
-  else alert('fail');
-};

--- a/apps/web/src/features/signup/model/utils/index.ts
+++ b/apps/web/src/features/signup/model/utils/index.ts
@@ -1,2 +1,1 @@
-export * from './handleFormSubmit';
 export * from './checkValidation';

--- a/apps/web/src/features/signup/types/form.ts
+++ b/apps/web/src/features/signup/types/form.ts
@@ -16,18 +16,24 @@ export type FormField = {
   button: string | null;
 };
 
-export interface FormInputProps {
+export type FormError = {
+  ACTION_NOT_COMPLETED: string;
+  AUTH_FAILURE: string;
+  AUTH_EXCEPTION: string;
+};
+
+export type FormInputProps = {
   id: FormItem;
   register: UseFormRegister<SignupInfo>;
   disabled?: boolean;
   className?: string;
   errors?: boolean;
   onChangeHandler?: (e: ChangeEvent<HTMLInputElement>) => void;
-}
+};
 
-export interface FormUnitProps {
+export type FormUnitProps = {
   id: FormItem;
   errors: FieldErrors<SignupInfo>;
   register: UseFormRegister<SignupInfo>;
   watch: UseFormWatch<SignupInfo>;
-}
+};

--- a/apps/web/src/features/signup/types/user.ts
+++ b/apps/web/src/features/signup/types/user.ts
@@ -1,5 +1,7 @@
 import { USER } from '~/features/signup/model';
 
+export type AuthId = { authId: number };
+
 export type SignupItem = keyof SignupInfo;
 
 export type SignupInfo = {

--- a/apps/web/src/features/signup/ui/EmailVerification.tsx
+++ b/apps/web/src/features/signup/ui/EmailVerification.tsx
@@ -24,10 +24,7 @@ export default function EmailVerification({ handler }: EmailVerificationProps) {
         size="sm"
         className="ml-3 h-[39px]"
         type="button"
-        onClick={() => {
-          handler(value);
-          console.log(value);
-        }}
+        onClick={() => handler(value)}
       >
         인증 확인
       </Button>

--- a/apps/web/src/features/signup/ui/FormInput.tsx
+++ b/apps/web/src/features/signup/ui/FormInput.tsx
@@ -4,7 +4,7 @@ import { Input } from '@soup/design-system';
 import { cn } from '@soup/utils';
 
 import { FORM, USER } from '~/features/signup/model';
-import { FormInputProps } from '~/features/signup/types';
+import type { FormInputProps } from '~/features/signup/types';
 
 export default function FormInput({
   id,

--- a/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
+++ b/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
@@ -53,17 +53,30 @@ export default function FormUnitWithButton({
           ? errors[USER[id]]?.message
           : valid[formId] && '*인증 완료'}
       </p>
-      <FormInput id={id} register={register} onChangeHandler={handleChange} />
-      <Button
-        color="normal"
-        size="sm"
-        className="ml-3 h-[39px]"
-        locked={!isFormValid(USER[id]) || buttonLocked}
-        type="button"
-        onClick={() => handler(watch(formId))}
-      >
-        {FORM[id].button}
-      </Button>
+      <div className="flex flex-1 flex-col">
+        <div className="flex items-end">
+          <FormInput
+            id={id}
+            register={register}
+            onChangeHandler={handleChange}
+          />
+          <Button
+            color="normal"
+            size="sm"
+            className="ml-3 h-[39px]"
+            locked={!isFormValid(USER[id]) || buttonLocked}
+            type="button"
+            onClick={() => handler(watch(formId))}
+          >
+            {FORM[id].button}
+          </Button>
+        </div>
+        <Description content={FORM[id].description || ''} />
+      </div>
     </div>
   );
 }
+
+const Description = ({ content }: { content: string }) => (
+  <p className="text-light mt-1 p-0 text-sm font-light">{content}</p>
+);

--- a/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
+++ b/apps/web/src/features/signup/ui/FormUnitWithButton.tsx
@@ -27,7 +27,9 @@ export default function FormUnitWithButton({
   watch,
 }: ButtonedUnitProps) {
   const formId = USER[id as 'ID' | 'EMAIL'];
-  const { setClicked, setValid } = useSignupContext();
+  const { clicked, setClicked, setValid } = useSignupContext();
+  const buttonLocked = id === 'EMAIL' && clicked[USER[id]] === true;
+
   const handleChange = () => {
     setClicked((prev) => ({
       ...prev,
@@ -56,7 +58,7 @@ export default function FormUnitWithButton({
         color="normal"
         size="sm"
         className="ml-3 h-[39px]"
-        locked={!isFormValid(USER[id])}
+        locked={!isFormValid(USER[id]) || buttonLocked}
         type="button"
         onClick={() => handler(watch(formId))}
       >

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
@@ -33,8 +33,8 @@ const Description = ({ content }: { content: string }) => (
 export default function SignupForm() {
   const { clicked, setClicked, valid, setValid } = useSignupContext();
   const navigate = useNavigate();
+  const [authId, setAuthId] = useState<number | undefined>(undefined);
 
-  const authId = 0; /**이메일 인증 백엔드 미구현으로 인해 샘플 응답값을 생성했습니다. */
   const schema = z.object({
     [USER.NAME]: z.string().min(1, '*'),
     [USER.ID]: z
@@ -92,12 +92,15 @@ export default function SignupForm() {
       ...prev,
       [USER.EMAIL]: true,
     }));
-    fetchEmailCode(email).then((response) => console.log(response));
+    fetchEmailCode(email).then(({ authId }) => {
+      setAuthId(authId);
+    });
   };
 
   const handleEmailCodeValidation = (authCode: string) => {
-    fetchEmailCodeValidation(authId, authCode)
+    fetchEmailCodeValidation(authId!, authCode)
       .then((isValid) => {
+        console.log(isValid, authCode);
         setValid((prev) => ({ ...prev, [USER.EMAIL]: isValid }));
         if (isValid) {
           clearErrors(USER.EMAIL);
@@ -115,9 +118,11 @@ export default function SignupForm() {
   };
 
   const handleFormSubmit = async (data: SignupInfo) => {
-    const response = await fetchUserJoin(data);
-    if (response === 200) navigate(PATH.LOGIN);
-    else alert('회원가입에 실패했어요!');
+    fetchUserJoin({ ...data, authId: authId! })
+      .then((response) => {
+        if (response === 200) navigate(PATH.LOGIN);
+      })
+      .catch((error) => alert(error.message));
   };
 
   const formProps = {

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -9,6 +8,8 @@ import {
   FORM,
   USER,
   useSignupContext,
+  useSignupHandlers,
+  useSignupSchema,
 } from '~/features/signup/model';
 import type { SignupInfo, SignupItem } from '~/features/signup/types';
 import {
@@ -17,14 +18,6 @@ import {
   EmailVerification,
   FormUnitWithButton,
 } from '~/features/signup/ui';
-import {
-  fetchEmailCode,
-  fetchEmailCodeValidation,
-  fetchIdValidation,
-  fetchUserJoin,
-} from '~/features/signup/api';
-import { useNavigate } from 'react-router-dom';
-import { PATH } from '~/shared/constants';
 
 const Description = ({ content }: { content: string }) => (
   <p className="text-light mt-1 p-0 text-sm font-light">{content}</p>
@@ -32,36 +25,7 @@ const Description = ({ content }: { content: string }) => (
 
 export default function SignupForm() {
   const { clicked, setClicked, valid, setValid } = useSignupContext();
-  const navigate = useNavigate();
-  const [authId, setAuthId] = useState<number | undefined>(undefined);
-
-  const schema = z.object({
-    [USER.NAME]: z.string().min(1, '*'),
-    [USER.ID]: z
-      .string()
-      .min(1, '*')
-      .refine(() => clicked[USER.ID], {
-        message: '*중복 확인 필요',
-      })
-      .refine(() => valid[USER.ID], { message: '*이미 사용중인 아이디입니다' }),
-    [USER.EMAIL]: z
-      .string()
-      .min(1, '*')
-      .refine(() => clicked[USER.EMAIL], {
-        message: '*이메일 인증 필요',
-      })
-      .refine(() => valid[USER.EMAIL], { message: '*코드가 틀렸습니다' }),
-    [USER.PW]: z
-      .string()
-      .min(8, '*')
-      .refine(
-        (password) => /^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,}$/.test(password),
-        {
-          message: '*올바르지 않은 비밀번호',
-        },
-      ),
-  });
-
+  const schema = useSignupSchema({ clicked, valid });
   const {
     register,
     handleSubmit,
@@ -71,59 +35,21 @@ export default function SignupForm() {
     setError,
   } = useForm<SignupInfo>({
     resolver: zodResolver(schema),
+    defaultValues: {
+      [USER.NAME]: '',
+      [USER.ID]: '',
+      [USER.EMAIL]: '',
+      [USER.PW]: '',
+    },
   });
+  const {
+    handleUsernameValidation,
+    handleEmailValidation,
+    handleEmailCodeValidation,
+    handleFormSubmit,
+  } = useSignupHandlers({ setClicked, setValid, clearErrors, setError });
 
   const isFormValid = (key: SignupItem) => checkValidation(watch(key), key);
-
-  const handleUsernameValidation = async (target: string) => {
-    setClicked((prev) => ({
-      ...prev,
-      [USER.ID]: true,
-    }));
-    fetchIdValidation(target).then((isValid) => {
-      setValid((prev) => ({ ...prev, [USER.ID]: isValid }));
-      if (isValid) clearErrors(USER.ID);
-      else setError(USER.ID, { message: '*이미 사용중인 아이디입니다' });
-    });
-  };
-
-  const handleEmailValidation = async (email: string) => {
-    setClicked((prev) => ({
-      ...prev,
-      [USER.EMAIL]: true,
-    }));
-    fetchEmailCode(email).then(({ authId }) => {
-      setAuthId(authId);
-    });
-  };
-
-  const handleEmailCodeValidation = (authCode: string) => {
-    fetchEmailCodeValidation(authId!, authCode)
-      .then((isValid) => {
-        console.log(isValid, authCode);
-        setValid((prev) => ({ ...prev, [USER.EMAIL]: isValid }));
-        if (isValid) {
-          clearErrors(USER.EMAIL);
-          setValid((prev) => ({
-            ...prev,
-            [USER.EMAIL]: true,
-          }));
-        } else setError(USER.EMAIL, { message: '*코드가 틀렸습니다' });
-      })
-      .catch(() =>
-        setError(USER.EMAIL, {
-          message: '*인증에 실패했어요. 다시 시도해 주세요.',
-        }),
-      );
-  };
-
-  const handleFormSubmit = async (data: SignupInfo) => {
-    fetchUserJoin({ ...data, authId: authId! })
-      .then((response) => {
-        if (response === 200) navigate(PATH.LOGIN);
-      })
-      .catch((error) => alert(error.message));
-  };
 
   const formProps = {
     errors: errors,

--- a/apps/web/src/features/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/signup/ui/SignupForm.tsx
@@ -7,7 +7,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   checkValidation,
   FORM,
-  handleFormSubmit,
   USER,
   useSignupContext,
 } from '~/features/signup/model';
@@ -22,7 +21,10 @@ import {
   fetchEmailCode,
   fetchEmailCodeValidation,
   fetchIdValidation,
+  fetchUserJoin,
 } from '~/features/signup/api';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '~/shared/constants';
 
 const Description = ({ content }: { content: string }) => (
   <p className="text-light mt-1 p-0 text-sm font-light">{content}</p>
@@ -30,6 +32,8 @@ const Description = ({ content }: { content: string }) => (
 
 export default function SignupForm() {
   const { clicked, setClicked, valid, setValid } = useSignupContext();
+  const navigate = useNavigate();
+
   const authId = 0; /**이메일 인증 백엔드 미구현으로 인해 샘플 응답값을 생성했습니다. */
   const schema = z.object({
     [USER.NAME]: z.string().min(1, '*'),
@@ -57,6 +61,7 @@ export default function SignupForm() {
         },
       ),
   });
+
   const {
     register,
     handleSubmit,
@@ -107,6 +112,12 @@ export default function SignupForm() {
           message: '*인증에 실패했어요. 다시 시도해 주세요.',
         }),
       );
+  };
+
+  const handleFormSubmit = async (data: SignupInfo) => {
+    const response = await fetchUserJoin(data);
+    if (response === 200) navigate(PATH.LOGIN);
+    else alert('회원가입에 실패했어요!');
   };
 
   const formProps = {

--- a/apps/web/src/shared/api/request.ts
+++ b/apps/web/src/shared/api/request.ts
@@ -1,4 +1,5 @@
 export const REQUEST = {
+  LOGIN: '/login',
   SIGNUP: '/v1/user/join',
   CHECK_VALID_ID: '/v1/user/valid/id',
   CHECK_VALID_EMAIL_CODE: '/v1/email/auth',

--- a/apps/web/src/shared/atoms/index.ts
+++ b/apps/web/src/shared/atoms/index.ts
@@ -1,2 +1,3 @@
 export * from './modal';
 export * from './project';
+export * from './user';

--- a/apps/web/src/shared/atoms/user.ts
+++ b/apps/web/src/shared/atoms/user.ts
@@ -1,0 +1,13 @@
+import { atom } from 'jotai';
+
+type Token = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+const initialUserState = {
+  accessToken: '',
+  refreshToken: '',
+};
+
+export const userAtom = atom<Token>(initialUserState);

--- a/apps/web/src/shared/hooks/useLoginStatus.ts
+++ b/apps/web/src/shared/hooks/useLoginStatus.ts
@@ -1,4 +1,8 @@
+import { useAtomValue } from 'jotai';
+import { userAtom } from '~/shared/atoms';
+
 export default function useLoginStatus() {
-  /* 로그인 여부 확인 로직, 차후 구현 */
-  return true;
+  const token = useAtomValue(userAtom);
+  const isAuthenticated = token.accessToken.length > 0;
+  return isAuthenticated;
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #43 

## 📝 작업 내용

> 로그인 API와 회원가입 API를 연동 완료했습니다.
- 이제 회원가입 화면을 통해 메일 인증을 할 수 있어요.
- 회원가입 폼 비즈니스 로직을 완전히 분리했어요.
- 로그인 실패 시(아이디 / 비밀번호 오류), 그리고 회원가입 실패 시(중복 이메일) 나타나는 모달은 다음 PR에 개발하겠습니다.
