### PR TITLE
[FEAT] : 로그인 실패 모달, `Auth` 인터셉터 구현

### DIFF
--- a/apps/web/src/features/login/model/atoms/index.ts
+++ b/apps/web/src/features/login/model/atoms/index.ts
@@ -1,0 +1,1 @@
+export * from './login';

--- a/apps/web/src/features/login/model/atoms/login.ts
+++ b/apps/web/src/features/login/model/atoms/login.ts
@@ -1,0 +1,6 @@
+import { atom } from 'jotai';
+
+export const loginErrorAtom = atom({
+  wrongCnt: 0,
+  wrongType: '',
+});

--- a/apps/web/src/features/login/model/constants/error.ts
+++ b/apps/web/src/features/login/model/constants/error.ts
@@ -1,0 +1,4 @@
+export const ERROR_CODE: Record<string, string> = {
+  P003: '비밀번호',
+  DT001: '아이디',
+};

--- a/apps/web/src/features/login/model/constants/index.ts
+++ b/apps/web/src/features/login/model/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './error';

--- a/apps/web/src/features/login/model/hooks/index.ts
+++ b/apps/web/src/features/login/model/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useLogin } from './useLogin';

--- a/apps/web/src/features/login/model/hooks/useLogin.ts
+++ b/apps/web/src/features/login/model/hooks/useLogin.ts
@@ -1,0 +1,37 @@
+import { useSetAtom } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+
+import { useModal } from '~/shared/hooks';
+import { ErrorWithCause } from '~/shared/api';
+import { MODAL, PATH } from '~/shared/constants';
+import { userAtom } from '~/shared/atoms';
+
+import { UserInfo } from '~/features/login/types';
+import { fetchUserLogin } from '~/features/login/api';
+import { loginErrorAtom, ERROR_CODE } from '~/features/login/model';
+
+export default function useLogin() {
+  const { openModal } = useModal();
+
+  const navigate = useNavigate();
+  const setUserAtom = useSetAtom(userAtom);
+  const setLoginAtom = useSetAtom(loginErrorAtom);
+
+  const handleFormSubmit = async (data: UserInfo) => {
+    try {
+      const response = await fetchUserLogin(data);
+      setUserAtom(response);
+      navigate(PATH.HOME);
+    } catch (error: unknown) {
+      const errorWithCause = error as ErrorWithCause;
+      const errorCode = errorWithCause.cause.code;
+      setLoginAtom((prev) => ({
+        wrongCnt: prev.wrongCnt + 1,
+        wrongType: ERROR_CODE[errorCode],
+      }));
+      openModal(MODAL.LOGIN_FAILED);
+    }
+  };
+
+  return { handleFormSubmit };
+}

--- a/apps/web/src/features/login/model/index.ts
+++ b/apps/web/src/features/login/model/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './hooks';
+export * from './atoms';

--- a/apps/web/src/features/login/ui/LoginFailedModal.tsx
+++ b/apps/web/src/features/login/ui/LoginFailedModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useAtomValue } from 'jotai';
+
+import { Button } from '@soup/design-system';
+
+import { useModal, useModalState } from '~/shared/hooks';
+import { Modal } from '~/shared/ui';
+import { MODAL } from '~/shared/constants';
+
+import { loginErrorAtom } from '~/features/login/model';
+
+export default function LoginFailedModal() {
+  const { closeModal } = useModal();
+  const { isOpen } = useModalState({ key: MODAL.LOGIN_FAILED });
+  const { wrongCnt, wrongType } = useAtomValue(loginErrorAtom);
+
+  return (
+    isOpen && (
+      <Modal
+        size="sm"
+        modalKey={MODAL.LOGIN_FAILED}
+        coloredBg={false}
+        className="flex max-h-[200px]"
+      >
+        <Modal.Body className="min-h-full justify-center font-light">
+          <Modal.Header title={`로그인 실패 ${wrongCnt}/5`} />
+          <u>잘못된 {wrongType}</u>
+          <p>4회 이상 추가 실패 시 30분 잠금</p>
+          <Modal.Footer className="m-0 flex justify-end">
+            <Button
+              className="w-[100px]"
+              color="normal"
+              onClick={() => closeModal(MODAL.LOGIN_FAILED)}
+            >
+              확인
+            </Button>
+          </Modal.Footer>
+        </Modal.Body>
+      </Modal>
+    )
+  );
+}

--- a/apps/web/src/features/login/ui/LoginForm.tsx
+++ b/apps/web/src/features/login/ui/LoginForm.tsx
@@ -1,27 +1,15 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
-import { useSetAtom } from 'jotai';
 
 import { Button, Input } from '@soup/design-system';
 
 import { LoginOption } from '~/features/login/ui';
 import { type UserInfo } from '~/features/login/types';
-import { fetchUserLogin } from '~/features/login/api';
-import { userAtom } from '~/shared/atoms';
-import { PATH } from '~/shared/constants';
+import { useLogin } from '~/features/login/model';
 
 export default function LoginForm() {
   const { register, handleSubmit } = useForm<UserInfo>();
-  const navigate = useNavigate();
-  const setUserAtom = useSetAtom(userAtom);
-
-  const handleFormSubmit = async (data: UserInfo) => {
-    fetchUserLogin(data).then((response) => {
-      setUserAtom(response);
-      navigate(PATH.HOME);
-    });
-  };
+  const { handleFormSubmit } = useLogin();
 
   return (
     <form onSubmit={handleSubmit(handleFormSubmit)}>

--- a/apps/web/src/features/login/ui/LoginForm.tsx
+++ b/apps/web/src/features/login/ui/LoginForm.tsx
@@ -43,7 +43,7 @@ export default function LoginForm() {
       <LoginOption className="mb-11" />
       <Button
         size="lg"
-        className="bg-point hover:bg-point-dark auth-button font-semibold text-white"
+        className="bg-point hover:bg-point-dark auth-button rounded-[10px] font-semibold text-white"
         type="submit"
       >
         로그인 하기

--- a/apps/web/src/features/login/ui/index.ts
+++ b/apps/web/src/features/login/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as LoginForm } from './LoginForm';
 export { default as LoginOption } from './LoginOption';
+export { default as LoginFailedModal } from './LoginFailedModal';

--- a/apps/web/src/features/signup/model/hooks/useSignupHandlers.ts
+++ b/apps/web/src/features/signup/model/hooks/useSignupHandlers.ts
@@ -49,12 +49,19 @@ export default function useSignupHandlers({
   };
 
   const handleEmailValidation = async (email: string) => {
-    setClicked((prev) => ({
-      ...prev,
-      [USER.EMAIL]: true,
-    }));
-    const { authId } = await fetchEmailCode(email);
-    setAuthId(authId);
+    try {
+      const { authId } = await fetchEmailCode(email);
+      clearErrors(USER.EMAIL);
+      setClicked((prev) => ({
+        ...prev,
+        [USER.EMAIL]: true,
+      }));
+      setAuthId(authId);
+    } catch (error: unknown) {
+      const convertedError = error as { message: string };
+      if (convertedError.message.includes('400'))
+        setError(USER.EMAIL, { message: '*이미 가입된 이메일이에요' });
+    }
   };
 
   const handleEmailCodeValidation = async (authCode: string) => {

--- a/apps/web/src/features/signup/ui/EmailVerification.tsx
+++ b/apps/web/src/features/signup/ui/EmailVerification.tsx
@@ -10,7 +10,7 @@ export default function EmailVerification({ handler }: EmailVerificationProps) {
   const [value, setValue] = useState<string>('');
 
   return (
-    <div className="relative mt-1 flex w-full items-end">
+    <div className="relative flex w-full items-end">
       <Input
         id="emailVerification"
         placeholder="인증코드를 입력해주세요"

--- a/apps/web/src/features/signup/ui/FormSubmit.tsx
+++ b/apps/web/src/features/signup/ui/FormSubmit.tsx
@@ -23,7 +23,7 @@ export default function FormSubmit() {
         size="lg"
         type="submit"
         disabled={!checked}
-        className="bg-point hover:bg-point-dark auth-button disabled:bg-main-board-border font-semibold text-white disabled:pointer-events-none"
+        className="bg-point hover:bg-point-dark auth-button disabled:bg-main-board-border rounded-[10px] font-semibold text-white disabled:pointer-events-none"
       >
         회원가입 하기
       </Button>

--- a/apps/web/src/shared/api/axios.ts
+++ b/apps/web/src/shared/api/axios.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosHeaders, AxiosResponse } from 'axios';
 
+export type ErrorWithCause = {
+  message: string;
+  cause: { code: string; message: null | string; desc: string };
+};
+
 interface GetRequestParams<TParams> {
   request: string;
   headers?: AxiosHeaders;
@@ -48,7 +53,8 @@ export async function post<TData, TResponse = unknown>(
     return response;
   } catch (error: unknown) {
     console.log(error);
-    if (axios.isAxiosError(error)) throw new Error(error.message);
+    if (axios.isAxiosError(error))
+      throw new Error(error.message, { cause: error.response?.data });
     else throw new Error('에러가 발생했습니다');
   }
 }

--- a/apps/web/src/shared/api/request.ts
+++ b/apps/web/src/shared/api/request.ts
@@ -1,6 +1,7 @@
 export const REQUEST = {
   LOGIN: '/login',
   SIGNUP: '/v1/user/join',
+  REFRESH: '/v1/user/refresh',
   CHECK_VALID_ID: '/v1/user/valid/id',
   CHECK_VALID_EMAIL_CODE: '/v1/email/auth',
   SEND_EMAIL_CODE: '/v1/email/auth/send',

--- a/apps/web/src/shared/api/user.ts
+++ b/apps/web/src/shared/api/user.ts
@@ -1,0 +1,78 @@
+import { getDefaultStore } from 'jotai';
+import axios, { AxiosError, AxiosHeaders, AxiosResponse } from 'axios';
+
+import { userAtom } from '~/shared/atoms';
+import { REQUEST, post } from '~/shared/api';
+
+interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface PostRequestParams<TData> {
+  request: string;
+  headers?: AxiosHeaders;
+  data: TData;
+}
+
+const instance = axios.create({
+  baseURL: 'http://student-p.p-e.kr/api',
+});
+
+instance.interceptors.request.use(async (config) => {
+  const store = getDefaultStore();
+  const { accessToken } = await store.get(userAtom);
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+instance.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      const store = getDefaultStore();
+      try {
+        const { refreshToken } = await store.get(userAtom);
+        const response = await post<
+          { refreshToken: string },
+          RefreshTokenResponse
+        >({
+          request: REQUEST.REFRESH,
+          data: { refreshToken },
+        });
+        const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
+          response.data;
+        store.set(userAtom, {
+          accessToken: newAccessToken,
+          refreshToken: newRefreshToken,
+        });
+      } catch (refreshError) {
+        console.log(refreshError);
+        store.set(userAtom, { accessToken: '', refreshToken: '' });
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+export async function userPost<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>,
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, data } = config;
+  try {
+    const response = await instance.post<
+      TResponse,
+      AxiosResponse<TResponse>,
+      TData
+    >(request, data, {
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}

--- a/apps/web/src/shared/atoms/user.ts
+++ b/apps/web/src/shared/atoms/user.ts
@@ -18,30 +18,3 @@ export const userAtom = atomWithStorage<Token>(
   initialUserState,
   sessionStorage as AsyncStorage<Token>,
 );
-
-// const authAtom = atom<User | null>(null);
-
-// auth 상태를 갱신하는 atom (초기, 로그인, 로그아웃 시)
-// const initAuthAtom = atom(null, async (get, set) => {
-//   const token = {
-//     access: sessionStorage.getItem('accessToken'),
-//     refresh: localStorage.getItem('refreshToken'),
-//   };
-
-//   if (token.access) {
-//     const authResponse = await getMe();
-//     if (authResponse.data) return set(authAtom, authResponse.data);
-//   }
-
-//   if (token.refresh) {
-//     const refreshResponse = await refreshAccessToken();
-//     if (refreshResponse.accessToken) {
-//       sessionStorage.setItem('accessToken', refreshResponse.accessToken);
-
-//       const authResponse = await getMe();
-//       if (authResponse.data) return set(authAtom, authResponse.data);
-//     }
-//   }
-
-//   return set(authAtom, null);
-// });

--- a/apps/web/src/shared/constants/modal.ts
+++ b/apps/web/src/shared/constants/modal.ts
@@ -19,6 +19,7 @@ export const MODAL = {
   LEVEL_INFO: 'levelInfo',
   CHANGE_PROJECT: 'changeProject',
   LEVEL_PROJECT: 'levelProject',
+  LOGIN_FAILED: 'loginFailed',
 } as const;
 
 export const SETTING_ITEM = {

--- a/apps/web/src/widgets/login/ui/LoginContainer.tsx
+++ b/apps/web/src/widgets/login/ui/LoginContainer.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { LoginForm } from '~/features/login/ui';
+import { LoginForm, LoginFailedModal } from '~/features/login/ui';
 import { SignupLink, SocialLogin } from '~/widgets/login/ui';
 
 export default function LoginContainer() {
   return (
-    <div className="relative flex size-full flex-col">
-      <LoginForm />
-      <SocialLogin />
-      <SignupLink />
-    </div>
+    <>
+      <div className="relative flex size-full flex-col">
+        <LoginForm />
+        <SocialLogin />
+        <SignupLink />
+      </div>
+      <LoginFailedModal />
+    </>
   );
 }

--- a/packages/design-system/src/Button/Button.styles.ts
+++ b/packages/design-system/src/Button/Button.styles.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  'font-regular border duration-300 ease-in-out rounded-[43px]',
+  'font-regular border duration-300 ease-in-out ',
   {
     variants: {
       color: {
@@ -12,8 +12,8 @@ export const buttonVariants = cva(
           'bg-normal hover:bg-normal-dark border-main-board-border text-dark',
       },
       size: {
-        lg: 'py-[12px] px-[28px]',
-        md: 'py-[8px] px-[20px] ',
+        lg: 'py-[12px] px-[28px] rounded-[10px]',
+        md: 'py-[8px] px-[20px] rounded-[43px]',
         sm: 'px-[12px] text-sm',
       },
       locked: {

--- a/packages/design-system/src/Button/Button.styles.ts
+++ b/packages/design-system/src/Button/Button.styles.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  'font-regular border duration-300 ease-in-out ',
+  'font-regular border duration-300 ease-in-out rounded-[43px]',
   {
     variants: {
       color: {
@@ -12,8 +12,8 @@ export const buttonVariants = cva(
           'bg-normal hover:bg-normal-dark border-main-board-border text-dark',
       },
       size: {
-        lg: 'py-[12px] px-[28px] rounded-[10px]',
-        md: 'py-[8px] px-[20px] rounded-[43px]',
+        lg: 'py-[12px] px-[28px]',
+        md: 'py-[8px] px-[20px]',
         sm: 'px-[12px] text-sm',
       },
       locked: {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #43 

## 📝 작업 내용

> 로그인 실패 모달과 회원가입 오류를 처리했습니다. axios interceptor를 통해 refresh 기능이 추가된 auth 구성하였습니다.
- 회원가입 (중복 이메일로 확인 코드 전송 요청 시) 오류를 처리했습니다.
- 로그인 실패 시 반환 코드에 따라 아이디와 비밀번호 오류 모달을 구현했습니다.
- 로그인 실패 횟수도 구현했으나, 특정 횟수가 넘었을 때 잠금 기능은 구현하지 않았습니다.
- axios interceptor를 통해 refresh 토큰을 사용한 token 핸들링 로직을 추가했습니다.

### 스크린샷 (선택)
<img width="1413" alt="image" src="https://github.com/user-attachments/assets/4bb5f9ff-5939-4e54-afe2-28e3a41af89e" />
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/2664b3f4-e122-4a1c-8a00-d80278c6d537" />

